### PR TITLE
fix: default icons to aria-hidden

### DIFF
--- a/icon-sprite/src/_shared.tsx
+++ b/icon-sprite/src/_shared.tsx
@@ -23,6 +23,7 @@ export type IconProps = React.SVGProps<SVGSVGElement> & {
 export function renderUse(id: string, path: string, { size, width, height, style, strokeWidth, ...rest }: IconProps) {
 	return (
 		<svg
+			aria-hidden="true"
 			{...rest}
 			width={width ?? size ?? 24}
 			height={height ?? size ?? 24}

--- a/icon-sprite/tests/run-all-tests.js
+++ b/icon-sprite/tests/run-all-tests.js
@@ -24,6 +24,11 @@ const testSuites = [
 		description: "Verify sprite IDs in wrappers match build-sprite mapping",
 	},
 	{
+		name: "Accessibility Props Tests",
+		file: "test-accessibility-props.test.js",
+		description: "Verify default aria-hidden behavior and consumer overrides",
+	},
+	{
 		name: "Config Loading Tests",
 		file: "test-config.test.js",
 		description: "Verify config loading and merging with defaults",

--- a/icon-sprite/tests/test-accessibility-props.test.js
+++ b/icon-sprite/tests/test-accessibility-props.test.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+/**
+ * Test: sprite-rendered icons match Lucide React's default accessibility behavior.
+ *
+ * Decorative icons should be hidden from assistive technology by default, while
+ * consumers can still override aria-hidden when an icon has semantic meaning.
+ */
+
+process.env.NODE_ENV = "production";
+
+try {
+	const { Activity } = await import("../dist/icons/Activity.js");
+
+	const defaultIcon = Activity({});
+	if (defaultIcon.props["aria-hidden"] !== "true") {
+		throw new Error(`Expected default aria-hidden to be "true", received ${defaultIcon.props["aria-hidden"]}`);
+	}
+
+	const exposedIcon = Activity({ "aria-hidden": "false", role: "img" });
+	if (exposedIcon.props["aria-hidden"] !== "false") {
+		throw new Error(`Expected aria-hidden override to be preserved, received ${exposedIcon.props["aria-hidden"]}`);
+	}
+
+	if (exposedIcon.props.role !== "img") {
+		throw new Error(`Expected role prop to be preserved, received ${exposedIcon.props.role}`);
+	}
+
+	console.log("✅ Default aria-hidden behavior matches lucide-react and remains overrideable.");
+} catch (e) {
+	console.error(`❌ Test failed: ${e.message}`);
+	process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add `aria-hidden="true"` by default to sprite-rendered icons
- keep consumer-provided accessibility props overrideable
- add a regression test for default and overridden `aria-hidden` behavior

## Validation
- `npm run build`
- `npm test`

Fixes #6